### PR TITLE
Fixed arguments variable for IE6-9

### DIFF
--- a/multicolumn.js
+++ b/multicolumn.js
@@ -146,7 +146,7 @@
         var _self = self;
         self.element.each(function() {
           var $el = $(this);
-          _self.destroy($el, _self.bind(_self.doColumns, $el, _self));
+          _self.destroy($el, _self.bind(_self.doColumns, [$el], _self));
         });
       })).trigger('resize');
     },
@@ -171,9 +171,9 @@
       }
     },
 
-    bind : function(fn, arguments, scope) {
+    bind : function(fn, args, scope) {
       return function () {
-        fn.apply(scope, arguments);
+        fn.apply(scope, args);
       };
     }
 


### PR DESCRIPTION
The `bind` function used `arguments` as variable name which is shadowed by the built-in `arguments` name in IE6-9. Minifying the JavaScript exposes this problem as `$el` is used for `apply` which causes the error `5028  Array or arguments object expected` in IE6-9.

This patch fixes this problem by changing the argument name in `bind` to `args` and using an array as second argument to `apply`.
